### PR TITLE
Fixes for Yuoki Industries recipe naming changes.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,182 +1,185 @@
 ---------------------------------------------------------------------------------------------------
-Version: 1.1.1
-Date:2021.10.31
+Version: 1.1.74
+Date: 2025.4.27
   Changes:
-    -Rebalanced Yuoki Player Equipment tech.
-    -Added equivalent Vanilla techs to Yuoki Player Equipment tech requirements.
-    -Rebalanced Yuoki Power Armor tech.
-    -Yuoki Basic Power now requires Yuoki Fluid Handling.
-    -Yuoki Basic Power now provides Boiler 3M6/4.
-    -Rebalanced Yuoki Basic Power.
-    -Rebalanced Yuoki Power.
-    -Added Yuoki Automation 4 through 6, to introduce the Y1 to Y3 Factories provided by Yuoki Engines mod. Removed these items from Intermediate Mechanical Force tech.
-    -Yuoki Electric Turrets tech now requires Laser Turrets tech.
-    -Rebalanced Yuoki Electric Turrets.
-    -Yuoki Advanced Item Transport tech now requires Logistics 3 tech.
-    -Rebalanced Yuoki Advanced Item Transport tech.
-    -Yuoki Advanced Power tech now requires Nuclear Power tech.
-    -Rebalanced Yuoki Advanced Power tech.
-    -Rebalanced Yuoki Advanced Modules tech.
+    - Fixed recipes to match current changes in Yuoki Industries (JATMN)
+    - Fixed Changelog formatting to process correctly in game (JATMN)
 ---------------------------------------------------------------------------------------------------
-Version: 1.1.2
-Date:2021.11.01
+Version: 1.1.73
+Date: 2024.12.13
   Changes:
-    -Moved Obninsk Reactor Cell from Yuoki Components tech to Yuoki Advanced Power tech.
-	-Yuoki Atomics tech now requires Yuoki Advanced Power tech.
-	-Rebalanced Yuoki Atomics.
-	-Rebalanced all techs requiring Yuoki Atomics.
-	-Yuoki Science Exchange tech now requires Space Science Pack tech.
-	-Yuoki Oil from Coal/Organics tech now requires Coal Liquefaction tech instead of Yuoki Unicomp Oil Products tech.
-	-Rebalanced Yuoki Oil from Coal/Organics tech.
-	-Added Yuoki Water Sulfurication tech, requires Sulfur Processing.
-	-Moved Sulfuric Acid from Toxic Dust/Water recipe from Yuoki Washing Raw Materials tech to Yuoki Water Sulfurization tech.
-	-Changed Yuoki Power icon to 1.8-MS-Turbine-S icon since Boiler 3M6/4 was moved to Yuoki Basic Power tech.
-	-Yuoki DNA Manipulation tech now requires Yuoki Automation 5 tech.
-	-Rebalanced Yuoki DNA Manipulation tech.
-	-Yuoki Trade Market tech now requires Yuoki Automation 4 tech.
-	-Rebalanced Yuoki Trade Market tech.
-	-Relevant recipes from Yuoki Trade Market tech will be moved to Yuoki DNA Manipulation tech when mod maker loops their head around them.
----------------------------------------------------------------------------------------------------
-Version: 1.1.3
-Date:2021.11.07
-  Changes:
-	-Added Yuoki DNA Trading tech, this tech was introduced to provide a sane place for the recipes
-	that were going to be moved from Yuoki Trade Market tech to Yuoki DNA Manipulation tech.
-    -Yuoki Trade Market tech now requires Yuoki Basic Farming tech.
-	-Moved recipes from Yuoki Trade Market tech to Yuoki DNA Trading tech.
-	-Yuoki Intermediate Mechanical Force tech now requires Lubricant tech, and Oil Processing tech. No longer requires Circuit Network tech.
-	-Moved all Solid Fuel Engine related technologies to Yuoki Intermediate Mechanical Force tech.
-	-Added Yuoki Research tech.
-	-Moved Research Center recipe, and Science Sign recipe from Yuoki Intermediate Mechanical Force to Yuoki Research tech.
-	-Added Yuoki Advanced Mechanical Force tech.
-	-Moved recipes from Yuoki Basic Mechanical Force, and Yuoki Intermediate Mechanical Force that involved Science signs to Yuoki Advanced Mechanical Force tech.
-	-Moved Liquid Fuel Engine recipe from Yuoki Quantum Mechanical Force tech to Yuoki Advanced Mechanical Force tech.
-	-Moved Liquid Fuel Engine related recipes from Yuoki Basic Mechanical Force tech to Yuoki Advanced Mechanical Force tech.
-	-Yuoki Quantum Mechanical Force tech now requires Yuoki Research tech, and Yuoki Atomics tech.
-	-Added Yuoki Fluid Handling 2 tech.
-	-Moved recipes from Yuoki Fluid Handling tech to Yuoki Fluid Handling 2 tech that require Pressure Proof Elements or Durotal Structure Elements.
-	-Moved Medium Water Generator recipe from Yuoki Advanced Machines tech to Yuoki Advanced Mechanical Force tech.
-	-Added Yuoki Fluid Handling 3 tech.
-	-Moved Underground Tank 50 kFU/33 recipe from Yuoki Advanced Machines tech to Yuoki Fluid Handling 3 tech.
-	-Yuoki Portable Fluids tech now requires Yuoki Intermediate Mechanical Force tech instead of Yuoki Basic Mechanical Force tech, and Yuoki Ranching instead of Yuoki Farming. 
-	Added Yuoki Fluid Handling as a requirement.
-	-Moved Alien Infuser, and related recipes from Yuoki Advanced Machines tech to Yuoki Atomics tech.
-	-Yuoki Advanced Ore Washing and Processing tech now requires Yuoki Inserters tech.
-	-Yuoki Ore Processing now requires Fluid Processing Tech. Changed icon to Crystalizer icon.
-	-Added Yuoki Mining tech.
-	-Moved YI E2 Mining Drill from Yuoki Ore Processing tech to Yuoki Mining tech.
-	-Added Yuoki Drying & Separation tech.
-	-Moved Dryer & Separator recipe from Yuoki Ore Processing tech to Yuoki Drying & Separation tech.
-	-Yuoki Reputation tech now requires Yuoki Atomics tech instead of Yuoki Advanced Machines tech.
-	-Added Yuoki Solar Energy tech.
-	-Moved Sun-Powered Stirling Solar Engine recipe from Yuoki Electric Machines tech to Yuoki Solar Energy tech.
-	-Added Yuoki Underground Mining tech.
-	-Moved Special Underground Drill recipe, and related recipes from Yuoki Electric Machines tech to Yuoki Underground Mining tech.
-	-Added Yuoki Solar Energy 2 tech.
-	-Changed Yuoki Power so it requires Oil Processing tech instead of Advanced Electronics tech. Removed Yuoki Components requirement since preceding tech requires it. Removed Solar Energy requirement.
-	-Moved Tiny Sol-Ray Stream Collector from Yuoki Power tech to Yuoki Solar Energy 2 tech.
-	-Changed Yuoki Electric Machines so it no longer requires Engine tech, preceding techs already have that requirement. Changed icon to Electric Crusher.
-	-Added Yuoki Electric Energy Distribution 1 tech.
-	-Added Yuoki Electric Energy Distribution 2 tech.
-	-Added Yuoki Electric Energy Distribution 3 tech.
-	-Moved Martin's Signal Connector recipe from Yuoki Power tech to Yuoki Electric Energy Distribution 1 tech.
-	-Moved Modified Substation St-a Recipe from Yuoki Power tech to Yuoki Electric Energy Distribution 2 tech.
-	-Moved AEET Substation from Yuoki Advanced Machines tech to Yuoki Electric Energy Distribution 3 tech.
-	-Added Yuoki Electric Energy Accumulators 1 tech.
-	-Added Yuoki Electric Energy Accumulators 2 tech.
-	-Added Yuoki Electric Energy Accumulators 3 tech.
-	-Added Yuoki Electric Energy Accumulators 4 tech.
-	-Added Yuoki Electric Energy Accumulators 5 tech.
-	-Added Yuoki Flywheel Energy Storage tech.
-	-Moved UPS Flywheel recipe from Yuoki Power tech to Yuoki Flywheel Energy Storage tech.
-	-Moved Accumulator recipes from Yuoki Power tech to Yuoki Electric Energy Accumulators techs.
-	-Moved Accumulator recipes from Yuoki Advanced Machines tech to Yuoki Electric Energy Accumulators 4 tech.
-	-Changed Yuoki Advanced Machines tech so it no longer requires Electric Motor tech. None of the recipes in that tech require them. Also removed Yuoki Fluid Handling, and Yuoki Power requirements.
-	-Moved AQE Accumulator, and Quantrinium Accumulator recipes from Yuoki Advanced Machines tech to Yuoki Electric Energy Accumulators 5 tech.
-	-Rebalanced Yuoki Power tech.
-	-Rebalanced Yuoki Advanced Machines tech.
-	-Rebalanced Yuoki Ore Processing tech.
-	-Rebalanced Yuoki Advanced Ore Washing and Processing tech.
-	-Rebalanced Yuoki Smelting tech.
-	-Rebalanced Yuoki Basic Mechanical Force tech.
-	-Rebalanced Yuoki Intermediate Mechanical Force tech.
-	-Rebalanced Yuoki Quantum Mechanical Force tech.
-	-Rebalanced Yuoki Farming tech.
-	-Rebalanced Yuoki Ranching tech.
-	-Reblaanced Yuoki Portable Fluids tech.
-	-Rebalanced Yuoki DNA Manipulation tech.
-	-Rebalanced Yuoki Reputation tech.
-	-Rebalanced Yuoki Reputation Ultimate tech.
----------------------------------------------------------------------------------------------------
-Version: 1.1.4
-Date:2021.12.05
-  Changes:
-	-Yuoki Smelting tech now requires Yuoki Advanced Machines tech.
-	-Rebalanced Yuoki Smelting tech.
-	-Fixed oversight where Yuoki Electric Energy Accumulators & Energy Distribution techs that require Electric Energy Distribution 2 did not require Chemical Science packs.
----------------------------------------------------------------------------------------------------
-Version: 1.1.5
-Date:2022.05.22
-  Changes:
-	-Yuoki Engines Gas-Fuel-Engine now requires Yuoki Intermediate Mechanical Force tech.
-	-Rheinsberg reactor related Steam recipes now require Yuoki Quantum Mechanical Force tech.
-	-Yuoki Railways Tile Factory, and related tiles now have techs to unlock them.
-	-Green pipes now require Yuoki Fluid Handling tech.
-	-Changed Yuoki Railways Steam Engines tech so it requires Automation 2 tech, and Advanced Material Processing tech. It now unlocks Locomotive workshop, Train Material Factory, and Cargo-wagon workshop.
-	Increased tech cost to 300. Changed icon to Locomotive workshop icon.
----------------------------------------------------------------------------------------------------
-Version: 1.1.6
-Date:2024.12.06
-  Changes:
-	-Updated for 2.0
-	-Several bugs present, such as icon sizes
-	-Some new recipes/changed recipes in recent Yuoki updates not caught so not in tech tree yet
----------------------------------------------------------------------------------------------------
-Version: 1.1.7
-Date:2024.12.08
-  Changes:
-	-Yuoki Ore Processing tech now requires Chemical science packs.
-	-Yuoki Mining tech now requires Chemical science packs.
-	-Yuoki Underground Mining tech now requires Chemical science packs.
-	-Yuoki Electric Machines tech now requires Chemical science packs.
-	-Yuoki Flywheel Energy Storage tech now requires Chemical science packs.
-	-Yuoki Advanced Machines tech now requires Chemical Science packs.
-	-Yuoki Fluid Handling 2 tech doubled science pack cost.
-	-Yuoki Fluid Handling 3 tech now requires Chemical Science packs.
-	-Renamed Yuoki Brick Wall technology to Yuoki Brick Walls.
-	-Yuoki Brick Walls technolog now requires Yuoki Raw Material Processing instead of Yuoki Components.
-	-Separated Yuoki Walls further in the tech tree so one tech doesn't unlock multiple types
-	-Yuoki Walls tech now requires Logistic Science packs. Now only unlocks Durotal Walls.
-	-New tech, Yuoki Advanced Walls, requires Yuoki Brick Walls, and Automation, Logistic, and Military science packs. Unlocks Krakon Walls.
-	-New Tech, Yuoki Hard Walls, requires Yuoki Advanced Walls & Yuoki Components, and Automation, Logistic, Military, and Chemical Science packs. Unlocks Hardic Wall.
-	-New Tech, Yuoki Force Field Walls, requires Energy Shield Equipment research & Yuoki Advanced Walls & Yuoki Components, and Automation, Logistic, Military, and Chemical Science packs. Unlocks Passive Vitduo Defense System.
-	-Yuoki Ammo Turrets tech no longer requires Yuoki Walls tech, instead Gun Turret tech is required. Tech also now requires Yuoki Components tech.
-	-Yuoki Mastercrafted Machines tech now requires 1000 science packs, and requires Chemical, Production, Utility science packs in addition to Automation, and Logistic science packs.
-	-Yuoki Electric Turrets now only unlocks T-LAS Eisenwulf Turret. No longer requires Yuoki Walls tech.
-	-New Tech Yuoki Hardened Laser Turret, requires Yuoki Hard Walls tech. Unlocks D-LAS Bonsai Turret.
-	-New Tech Yuoki Plasma Turret, unlocks T-PLASMA Turret.
-	-New Tech Yuoki ZTT Turret, unlocks D-ZTT jorgenRe Turret.
-	-Yuoki Solar Energy now requires Chemical Science packs.
-	-Yuoki Solar Energy 2 is now known as Yuoki Concentrated Solar Collector tech, and requires Chemical, and Utility Science Packs.
-	-Yuoki Modules now requires Productivity Module, Efficiency Module, and Speed Module techs instead of Modules tech, and now requires Chemical Science packs. Doubled tech cost.
-	-Yuoki Advanced Modules now requires Productivity Module 2, Efficiency Module 2, and Speed Module 2 techs.
-	-Yuoki Advanced Power now requires Yuoki Power tech instead of Nuclear Power tech. Removed Obnisk Reaktor AM-1/1951, Rensuir Turbine, Fusion Fuel Mixer and related recipes from tech.
-	-New Tech Yuoki Advanced Nuclear Power, requires Yuoki Advanced Power tech & Nuclear Power tech. Unlocks Obnisk Reaktor AM-1/1951, Rensuir Turbine, Fusion Fuel Mixer, and related recipes.
-	-Yuoki Atomics now requires Yuoki Advanced Nuclear Power tech instead of Yuoki Advanced Power.
-	-Fixed Yuoki Engines related techs not working cause of a recipe name change
-	-Caught all new/changed recipes in techs, now all Yuoki items should be unlocked by a tech.
----------------------------------------------------------------------------------------------------
-Version: 1.1.71
-Date:2024.12.08
-  Changes:
-	-Fix icon size errors caused by Yuoki Engines techs
+    - Fix mod not working on just base Factorio due to referencing a no longer existing technology fusion-reactor-equipment(only reintroduced in Space Age expansion).
 ---------------------------------------------------------------------------------------------------
 Version: 1.1.72
-Date:2024.12.12
+Date: 2024.12.12
   Changes:
-	-Fix mod not working on just base Factorio due to referencing a no longer existing technology stack-inserter(only reintroduced in Space Age expansion).
-	---------------------------------------------------------------------------------------------------
-Version: 1.1.73
-Date:2024.12.13
+    - Fix mod not working on just base Factorio due to referencing a no longer existing technology stack-inserter(only reintroduced in Space Age expansion).
+---------------------------------------------------------------------------------------------------
+Version: 1.1.71
+Date: 2024.12.08
   Changes:
-	-Fix mod not working on just base Factorio due to referencing a no longer existing technology fusion-reactor-equipment(only reintroduced in Space Age expansion).
+    - Fix icon size errors caused by Yuoki Engines techs
+---------------------------------------------------------------------------------------------------
+Version: 1.1.7
+Date: 2024.12.08
+  Changes:
+    - Yuoki Ore Processing tech now requires Chemical science packs.
+    - Yuoki Mining tech now requires Chemical science packs.
+    - Yuoki Underground Mining tech now requires Chemical science packs.
+    - Yuoki Electric Machines tech now requires Chemical science packs.
+    - Yuoki Flywheel Energy Storage tech now requires Chemical science packs.
+    - Yuoki Advanced Machines tech now requires Chemical Science packs.
+    - Yuoki Fluid Handling 2 tech doubled science pack cost.
+    - Yuoki Fluid Handling 3 tech now requires Chemical Science packs.
+    - Renamed Yuoki Brick Wall technology to Yuoki Brick Walls.
+    - Yuoki Brick Walls technolog now requires Yuoki Raw Material Processing instead of Yuoki Components.
+    - Separated Yuoki Walls further in the tech tree so one tech doesn't unlock multiple types
+    - Yuoki Walls tech now requires Logistic Science packs. Now only unlocks Durotal Walls.
+    - New tech, Yuoki Advanced Walls, requires Yuoki Brick Walls, and Automation, Logistic, and Military science packs. Unlocks Krakon Walls.
+    - New Tech, Yuoki Hard Walls, requires Yuoki Advanced Walls & Yuoki Components, and Automation, Logistic, Military, and Chemical Science packs. Unlocks Hardic Wall.
+    - New Tech, Yuoki Force Field Walls, requires Energy Shield Equipment research & Yuoki Advanced Walls & Yuoki Components, and Automation, Logistic, Military, and Chemical Science packs. Unlocks Passive Vitduo Defense System.
+    - Yuoki Ammo Turrets tech no longer requires Yuoki Walls tech, instead Gun Turret tech is required. Tech also now requires Yuoki Components tech.
+    - Yuoki Mastercrafted Machines tech now requires 1000 science packs, and requires Chemical, Production, Utility science packs in addition to Automation, and Logistic science packs.
+    - Yuoki Electric Turrets now only unlocks T-LAS Eisenwulf Turret. No longer requires Yuoki Walls tech.
+    - New Tech Yuoki Hardened Laser Turret, requires Yuoki Hard Walls tech. Unlocks D-LAS Bonsai Turret.
+    - New Tech Yuoki Plasma Turret, unlocks T-PLASMA Turret.
+    - New Tech Yuoki ZTT Turret, unlocks D-ZTT jorgenRe Turret.
+    - Yuoki Solar Energy now requires Chemical Science packs.
+    - Yuoki Solar Energy 2 is now known as Yuoki Concentrated Solar Collector tech, and requires Chemical, and Utility Science Packs.
+    - Yuoki Modules now requires Productivity Module, Efficiency Module, and Speed Module techs instead of Modules tech, and now requires Chemical Science packs. Doubled tech cost.
+    - Yuoki Advanced Modules now requires Productivity Module 2, Efficiency Module 2, and Speed Module 2 techs.
+    - Yuoki Advanced Power now requires Yuoki Power tech instead of Nuclear Power tech. Removed Obnisk Reaktor AM-1/1951, Rensuir Turbine, Fusion Fuel Mixer and related recipes from tech.
+    - New Tech Yuoki Advanced Nuclear Power, requires Yuoki Advanced Power tech & Nuclear Power tech. Unlocks Obnisk Reaktor AM-1/1951, Rensuir Turbine, Fusion Fuel Mixer, and related recipes.
+    - Yuoki Atomics now requires Yuoki Advanced Nuclear Power tech instead of Yuoki Advanced Power.
+    - Fixed Yuoki Engines related techs not working cause of a recipe name change
+    - Caught all new/changed recipes in techs, now all Yuoki items should be unlocked by a tech.
+---------------------------------------------------------------------------------------------------
+Version: 1.1.6
+Date: 2024.12.06
+  Changes:
+    - Updated for 2.0
+    - Several bugs present, such as icon sizes
+    - Some new recipes/changed recipes in recent Yuoki updates not caught so not in tech tree yet
+---------------------------------------------------------------------------------------------------
+Version: 1.1.5
+Date: 2022.05.22
+  Changes:
+    - Yuoki Engines Gas-Fuel-Engine now requires Yuoki Intermediate Mechanical Force tech.
+    - Rheinsberg reactor related Steam recipes now require Yuoki Quantum Mechanical Force tech.
+    - Yuoki Railways Tile Factory, and related tiles now have techs to unlock them.
+    - Green pipes now require Yuoki Fluid Handling tech.
+    - Changed Yuoki Railways Steam Engines tech so it requires Automation 2 tech, and Advanced Material Processing tech. It now unlocks Locomotive workshop, Train Material Factory, and Cargo-wagon workshop. Increased tech cost to 300. Changed icon to Locomotive workshop icon.
+---------------------------------------------------------------------------------------------------
+Version: 1.1.4
+Date: 2021.12.05
+  Changes:
+    - Yuoki Smelting tech now requires Yuoki Advanced Machines tech.
+    - Rebalanced Yuoki Smelting tech.
+    - Fixed oversight where Yuoki Electric Energy Accumulators & Energy Distribution techs that require Electric Energy Distribution 2 did not require Chemical Science packs.
+---------------------------------------------------------------------------------------------------
+Version: 1.1.3
+Date: 2021.11.07
+  Changes:
+    - Added Yuoki DNA Trading tech, this tech was introduced to provide a sane place for the recipes that were going to be moved from Yuoki Trade Market tech to Yuoki DNA Manipulation tech.
+    - Yuoki Trade Market tech now requires Yuoki Basic Farming tech.
+    - Moved recipes from Yuoki Trade Market tech to Yuoki DNA Trading tech.
+    - Yuoki Intermediate Mechanical Force tech now requires Lubricant tech, and Oil Processing tech. No longer requires Circuit Network tech.
+    - Moved all Solid Fuel Engine related technologies to Yuoki Intermediate Mechanical Force tech.
+    - Added Yuoki Research tech.
+    - Moved Research Center recipe, and Science Sign recipe from Yuoki Intermediate Mechanical Force to Yuoki Research tech.
+    - Added Yuoki Advanced Mechanical Force tech.
+    - Moved recipes from Yuoki Basic Mechanical Force, and Yuoki Intermediate Mechanical Force that involved Science signs to Yuoki Advanced Mechanical Force tech.
+    - Moved Liquid Fuel Engine recipe from Yuoki Quantum Mechanical Force tech to Yuoki Advanced Mechanical Force tech.
+    - Moved Liquid Fuel Engine related recipes from Yuoki Basic Mechanical Force tech to Yuoki Advanced Mechanical Force tech.
+    - Yuoki Quantum Mechanical Force tech now requires Yuoki Research tech, and Yuoki Atomics tech.
+    - Added Yuoki Fluid Handling 2 tech.
+    - Moved recipes from Yuoki Fluid Handling tech to Yuoki Fluid Handling 2 tech that require Pressure Proof Elements or Durotal Structure Elements.
+    - Moved Medium Water Generator recipe from Yuoki Advanced Machines tech to Yuoki Advanced Mechanical Force tech.
+    - Added Yuoki Fluid Handling 3 tech.
+    - Moved Underground Tank 50 kFU/33 recipe from Yuoki Advanced Machines tech to Yuoki Fluid Handling 3 tech.
+    - Yuoki Portable Fluids tech now requires Yuoki Intermediate Mechanical Force tech instead of Yuoki Basic Mechanical Force tech, and Yuoki Ranching instead of Yuoki Farming. Added Yuoki Fluid Handling as a requirement.
+    - Moved Alien Infuser, and related recipes from Yuoki Advanced Machines tech to Yuoki Atomics tech.
+    - Yuoki Advanced Ore Washing and Processing tech now requires Yuoki Inserters tech.
+    - Yuoki Ore Processing now requires Fluid Processing Tech. Changed icon to Crystalizer icon.
+    - Added Yuoki Mining tech.
+    - Moved YI E2 Mining Drill from Yuoki Ore Processing tech to Yuoki Mining tech.
+    - Added Yuoki Drying & Separation tech.
+    - Moved Dryer & Separator recipe from Yuoki Ore Processing tech to Yuoki Drying & Separation tech.
+    - Yuoki Reputation tech now requires Yuoki Atomics tech instead of Yuoki Advanced Machines tech.
+    - Added Yuoki Solar Energy tech.
+    - Moved Sun-Powered Stirling Solar Engine recipe from Yuoki Electric Machines tech to Yuoki Solar Energy tech.
+    - Added Yuoki Underground Mining tech.
+    - Moved Special Underground Drill recipe, and related recipes from Yuoki Electric Machines tech to Yuoki Underground Mining tech.
+    - Added Yuoki Solar Energy 2 tech.
+    - Changed Yuoki Power so it requires Oil Processing tech instead of Advanced Electronics tech. Removed Yuoki Components requirement since preceding tech requires it. Removed Solar Energy requirement.
+    - Moved Tiny Sol-Ray Stream Collector from Yuoki Power tech to Yuoki Solar Energy 2 tech.
+    - Changed Yuoki Electric Machines so it no longer requires Engine tech, preceding techs already have that requirement. Changed icon to Electric Crusher.
+    - Added Yuoki Electric Energy Distribution 1 tech.
+    - Added Yuoki Electric Energy Distribution 2 tech.
+    - Added Yuoki Electric Energy Distribution 3 tech.
+    - Moved Martin's Signal Connector recipe from Yuoki Power tech to Yuoki Electric Energy Distribution 1 tech.
+    - Moved Modified Substation St-a Recipe from Yuoki Power tech to Yuoki Electric Energy Distribution 2 tech.
+    - Moved AEET Substation from Yuoki Advanced Machines tech to Yuoki Electric Energy Distribution 3 tech.
+    - Added Yuoki Electric Energy Accumulators 1 tech.
+    - Added Yuoki Electric Energy Accumulators 2 tech.
+    - Added Yuoki Electric Energy Accumulators 3 tech.
+    - Added Yuoki Electric Energy Accumulators 4 tech.
+    - Added Yuoki Electric Energy Accumulators 5 tech.
+    - Added Yuoki Flywheel Energy Storage tech.
+    - Moved UPS Flywheel recipe from Yuoki Power tech to Yuoki Flywheel Energy Storage tech.
+    - Moved Accumulator recipes from Yuoki Power tech to Yuoki Electric Energy Accumulators techs.
+    - Moved Accumulator recipes from Yuoki Advanced Machines tech to Yuoki Electric Energy Accumulators 4 tech.
+    - Changed Yuoki Advanced Machines tech so it no longer requires Electric Motor tech. None of the recipes in that tech require them. Also removed Yuoki Fluid Handling, and Yuoki Power requirements.
+    - Moved AQE Accumulator, and Quantrinium Accumulator recipes from Yuoki Advanced Machines tech to Yuoki Electric Energy Accumulators 5 tech.
+    - Rebalanced Yuoki Power tech.
+    - Rebalanced Yuoki Advanced Machines tech.
+    - Rebalanced Yuoki Ore Processing tech.
+    - Rebalanced Yuoki Advanced Ore Washing and Processing tech.
+    - Rebalanced Yuoki Smelting tech.
+    - Rebalanced Yuoki Basic Mechanical Force tech.
+    - Rebalanced Yuoki Intermediate Mechanical Force tech.
+    - Rebalanced Yuoki Quantum Mechanical Force tech.
+    - Rebalanced Yuoki Farming tech.
+    - Rebalanced Yuoki Ranching tech.
+    - Reblaanced Yuoki Portable Fluids tech.
+    - Rebalanced Yuoki DNA Manipulation tech.
+    - Rebalanced Yuoki Reputation tech.
+    - Rebalanced Yuoki Reputation Ultimate tech.
+---------------------------------------------------------------------------------------------------
+Version: 1.1.2
+Date: 2021.11.01
+  Changes:
+    - Moved Obninsk Reactor Cell from Yuoki Components tech to Yuoki Advanced Power tech.
+    - Yuoki Atomics tech now requires Yuoki Advanced Power tech.
+    - Rebalanced Yuoki Atomics.
+    - Rebalanced all techs requiring Yuoki Atomics.
+    - Yuoki Science Exchange tech now requires Space Science Pack tech.
+    - Yuoki Oil from Coal/Organics tech now requires Coal Liquefaction tech instead of Yuoki Unicomp Oil Products tech.
+    - Rebalanced Yuoki Oil from Coal/Organics tech.
+    - Added Yuoki Water Sulfurication tech, requires Sulfur Processing.
+    - Moved Sulfuric Acid from Toxic Dust/Water recipe from Yuoki Washing Raw Materials tech to Yuoki Water Sulfurization tech.
+    - Changed Yuoki Power icon to 1.8-MS-Turbine-S icon since Boiler 3M6/4 was moved to Yuoki Basic Power tech.
+    - Yuoki DNA Manipulation tech now requires Yuoki Automation 5 tech.
+    - Rebalanced Yuoki DNA Manipulation tech.
+    - Yuoki Trade Market tech now requires Yuoki Automation 4 tech.
+    - Rebalanced Yuoki Trade Market tech.
+    - Relevant recipes from Yuoki Trade Market tech will be moved to Yuoki DNA Manipulation tech when mod maker loops their head around them.
+---------------------------------------------------------------------------------------------------
+Version: 1.1.1
+Date: 2021.10.31
+  Changes:
+    - Rebalanced Yuoki Player Equipment tech.
+    - Added equivalent Vanilla techs to Yuoki Player Equipment tech requirements.
+    - Rebalanced Yuoki Power Armor tech.
+    - Yuoki Basic Power now requires Yuoki Fluid Handling.
+    - Yuoki Basic Power now provides Boiler 3M6/4.
+    - Rebalanced Yuoki Basic Power.
+    - Rebalanced Yuoki Power.
+    - Added Yuoki Automation 4 through 6, to introduce the Y1 to Y3 Factories provided by Yuoki Engines mod. Removed these items from Intermediate Mechanical Force tech.
+    - Yuoki Electric Turrets tech now requires Laser Turrets tech.
+    - Rebalanced Yuoki Electric Turrets.
+    - Yuoki Advanced Item Transport tech now requires Logistics 3 tech.
+    - Rebalanced Yuoki Advanced Item Transport tech.
+    - Yuoki Advanced Power tech now requires Nuclear Power tech.
+    - Rebalanced Yuoki Advanced Power tech.
+    - Rebalanced Yuoki Advanced Modules tech.

--- a/info.json
+++ b/info.json
@@ -1,13 +1,13 @@
 {
   "name": "Yi_Tech_Tree_ExtraVanilla",
-  "version": "1.1.73",
+  "version": "1.1.74",
   "factorio_version": "2.0",
   "dependencies": [
   "base >= 2.0.20", 
   "! Yi_Tech_Tree >= 0.14.10", 
-  "Yuoki >= 1.2.0", 
-  "? yi_engines >= 1.2.1",
-  "? yi_railway >= 1.1.28"
+  "Yuoki >= 1.2.13", 
+  "? yi_engines >= 1.2.7",
+  "? yi_railway >= 1.2.1"
   ],
   "title": "Yuoki Tech Tree Extra Vanilla",
   "author": "MnHebi",

--- a/prototypes/technology/yi_core.lua
+++ b/prototypes/technology/yi_core.lua
@@ -29,7 +29,7 @@ table.insert(tiers,
 				},	
 				{
 					type = "unlock-recipe",
-					recipe = "y-coaldust"
+					recipe = "y-coal-dust"
 				},	
 			},
 			prerequisites = {"automation"},
@@ -109,7 +109,7 @@ table.insert(tiers,
 			{
 			  {
 				type = "unlock-recipe",
-				recipe = "y_c11"
+				recipe = "y_sc11"
 			  },
 			  {
 				type = "unlock-recipe",
@@ -308,11 +308,11 @@ table.insert(tiers,
 			  },
 			  {
 				type = "unlock-recipe",
-				recipe = "y-chip1"
+				recipe = "y-chip-1"
 			  },
 			  {
 				type = "unlock-recipe",
-				recipe = "y-chip2"
+				recipe = "y-chip-2"
 			  },
 			  {
 				type = "unlock-recipe",
@@ -344,7 +344,7 @@ table.insert(tiers,
 			  },
 			  {
 				type = "unlock-recipe",
-				recipe = "y-ammo-acid-medium"
+				recipe = "y-ammo-acid-2"
 			  },
 			  {
 				type = "unlock-recipe",
@@ -580,7 +580,7 @@ table.insert(tiers,
 			{
 			  {
 				type = "unlock-recipe",
-				recipe = "y-solar-dish"
+				recipe = "y-stirling-solar-dish"
 			  },
 			},
 			unit =
@@ -619,11 +619,11 @@ table.insert(tiers,
 				},
 				{
 					type = "unlock-recipe",
-					recipe = "y-battery-singleuse1"
+					recipe = "y-battery-single-use1"
 				},
 				{
 					type = "unlock-recipe",
-					recipe = "y-battery-singleuse2"
+					recipe = "y-battery-single-use2"
 				},
 			},
 			unit =
@@ -743,7 +743,7 @@ table.insert(tiers,
 				},
 				{
 					type = "unlock-recipe",
-					recipe = "y_inserter_smart",
+					recipe = "y-inserter-smart",
 				},
 				{
 					type = "unlock-recipe",
@@ -844,7 +844,7 @@ table.insert(tiers,
 			{
 			  {
 				type = "unlock-recipe",
-				recipe = "y-basic-st1-mf"
+				recipe = "y-basic-t1-mf"
 			  },
 			  {
 				type = "unlock-recipe",
@@ -908,15 +908,15 @@ table.insert(tiers,
 			{
 			  {
 				type = "unlock-recipe",
-				recipe = "y_ammo_case_recipe"
+				recipe = "y_ammo_case"
 			  },
 			  {
 				type = "unlock-recipe",
-				recipe = "y_ammo_plasma_recipe"
+				recipe = "y_ammo_plasma"
 			  },
 			  {
 				type = "unlock-recipe",
-				recipe = "y_ammo_flame_recipe"
+				recipe = "y_ammo_flame"
 			  },	  
 			},
 			unit =
@@ -1153,7 +1153,7 @@ table.insert(tiers,
 			{
 			  {
 				type = "unlock-recipe",
-				recipe = "y-gun-turret-mk2"
+				recipe = "y_turret_gun2f12"
 			  },
 			},
 			unit =
@@ -1178,7 +1178,7 @@ table.insert(tiers,
 			{
 				{
 					type = "unlock-recipe",
-					recipe = "y-basic-st2-mf",
+					recipe = "y-basic-t2-mf",
 				},
 				{
 					type = "unlock-recipe",
@@ -1256,8 +1256,8 @@ table.insert(tiers,
 			{
 			  {
 				type = "unlock-recipe",
-				recipe = "y_ammo_shell_recipe"
-			  },	  
+				recipe = "yi_cannon_shell"
+			  },
 			},
 			unit =
 			{
@@ -1282,7 +1282,7 @@ table.insert(tiers,
 			{
 			  {
 				type = "unlock-recipe",
-				recipe = "y_ammo_artillery_recipe"
+				recipe = "yi_artillery_shell"
 			  },  	  
 			},
 			unit =
@@ -1308,7 +1308,7 @@ table.insert(tiers,
 			{
 			  {
 				type = "unlock-recipe",
-				recipe = "y-gun-turret-mk3"
+				recipe = "y_turret_gun1f12"
 			  },
 			},
 			unit =
@@ -1501,7 +1501,7 @@ table.insert(tiers,
 			{
 			  {
 				type = "unlock-recipe",
-				recipe = "y_laser_mk1"
+				recipe = "y_turret_laser22f12"
 			  },
 			},
 			unit =
@@ -1715,7 +1715,7 @@ table.insert(tiers,
 				
 				{
 					type = "unlock-recipe",
-					recipe = "y-sgtrade-ic1",
+					recipe = "y-fuel-cell-c",
 				},
 				{
 					type = "unlock-recipe",
@@ -1935,7 +1935,7 @@ table.insert(tiers,
 			  },
 				{
 				type = "unlock-recipe",
-				recipe = "yi_equip_pld"
+				recipe = "yi_pld_equipment"
 			  },
 			  {
 				type = "unlock-recipe",
@@ -2433,11 +2433,11 @@ table.insert(tiers,
 			{
 				{
 					type = "unlock-recipe",
-					recipe = "y-accumulator-mt2",
+					recipe = "y-accumulator-m-t2",
 				},
 				{
 					type = "unlock-recipe",
-					recipe = "y-accumulator-bt2",
+					recipe = "y-accumulator-b-t2",
 				},		
 			},
 			prerequisites = {"yi-advanced-machines", "yi-electric-energy-accumulators-3"},
@@ -2462,7 +2462,7 @@ table.insert(tiers,
 			{
 			  {
 				type = "unlock-recipe",
-				recipe = "y_laser_onhwall"
+				recipe = "y-laser-def-s4"
 			  },
 			},
 			unit =
@@ -2546,10 +2546,6 @@ table.insert(tiers,
 				},
 				{
 					type = "unlock-recipe",
-					recipe = "y_mox2fuel"
-				},
-				{
-					type = "unlock-recipe",
 					recipe = "y_reactor_mf1"
 				},
 				{
@@ -2562,7 +2558,7 @@ table.insert(tiers,
 				},
 				{
 					type = "unlock-recipe",
-					recipe = "y_mox2fuelsplit"
+					recipe = "y_mox2fuelsplited"
 				},
 				{
 					type = "unlock-recipe",
@@ -2830,7 +2826,7 @@ table.insert(tiers,
 			{
 				{
 					type = "unlock-recipe",
-					recipe = "y-accumulator-btx",
+					recipe = "y-accumulator-b-tx",
 				},
 				{
 					type = "unlock-recipe",


### PR DESCRIPTION
Fixed recipe name changes to align with changes in YI.
Fixed Changelog - this was upside down (Factorio wants most recent updates at the top) and it also used incorrect tab formatting to be correctly processed by the game.
Changed minimum version dependencies for Yi related mods. Versioned up the mod to 1.1.74.
Didnt make changes for Yi Railways, this is still broken and appears it was never completed in the first place? It mostly needs just redone.